### PR TITLE
Allow paths starting with a hash

### DIFF
--- a/dist/router.es5.js
+++ b/dist/router.es5.js
@@ -1567,9 +1567,7 @@ var CanonicalRecognizer = function CanonicalRecognizer(name) {
       }
     },
     getCanonicalUrl: function(url) {
-      if (url[0] === '.') {
-        url = url.substr(1);
-      } else if (url[0] === '#') {
+      if (url[0] === '.' || url[0] === '#') {
         url = url.substr(1);
       }
       if (url === '' || url[0] !== '/') {

--- a/dist/router.es5.js
+++ b/dist/router.es5.js
@@ -1569,6 +1569,8 @@ var CanonicalRecognizer = function CanonicalRecognizer(name) {
     getCanonicalUrl: function(url) {
       if (url[0] === '.') {
         url = url.substr(1);
+      } else if (url[0] === '#') {
+        url = url.substr(1);
       }
       if (url === '' || url[0] !== '/') {
         url = '/' + url;


### PR DESCRIPTION
@isuda @dpogue 

Basically after the latest changes the urls starting with `#` are considered 404 and then mapped to the default path.

I'm not sure if this is the best solution, but it works. I'd need more time to understand this router stuff.

Using the same logic as https://github.com/AyogoHealth/router/compare/master...AyogoHealth:404-fix?expand=1#diff-98b7672b9a948fa2b19152b7f5a001c6R1570
