### PR TITLE
Move traceur to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "requirejs": "^2.1.15",
-    "route-recognizer": "git://github.com/btford/route-recognizer",
-    "traceur": "^0.0.72"
+    "route-recognizer": "git://github.com/btford/route-recognizer"
   },
   "devDependencies": {
     "angular": "^1.3.7",
@@ -50,7 +49,8 @@
     "marked": "^0.3.2",
     "protractor": "^0.21.0",
     "q": "^1.1.2",
-    "through2": "^0.4.1"
+    "through2": "^0.4.1",
+    "traceur": "^0.0.72"
   },
   "scripts": {
     "test": "karma start --single-run"


### PR DESCRIPTION
I'm pretty sure the dist code for this repo has no actual dependencies, but moving traceur allows us to stop getting npm warnings about ancient minimatch versions.